### PR TITLE
Add InsightFace C++ sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Clone this repository and enter the directory.
 ```shell
   git clone https://github.com/ArduCAM/Arducam_tof_camera.git
   cd Arducam_tof_camera
+  # clone InsightFace for C++ face recognition
+  git clone https://github.com/deepinsight/insightface.git third_party/insightface
 ```
 
 ### Install dependencies for Raspberry Pi
@@ -63,6 +65,9 @@ Clone this repository and enter the directory.
   python3 preview_depth.py
   #or
   python3 capture_raw.py
+  #or
+  python3 insightface_register.py
+  # Press 'r' to save a face embedding and quit with 'q'
 ```
 
 #### C/C++
@@ -101,6 +106,8 @@ Clone this repository and enter the directory.
   ./preview_depth
   #or
   ./capture_raw
+  #or
+  ./face_identifier  # register or identify faces using InsightFace
 ```
 
 ### Point Cloud Examples

--- a/compile.sh
+++ b/compile.sh
@@ -12,7 +12,8 @@ fi
 if cmake --build $workpath/build --config Release --target example -j 4 &&
     cmake --build $workpath/build --config Release --target capture_raw -j 4 &&
     cmake --build $workpath/build --config Release --target preview_depth -j 4 &&
-    cmake --build $workpath/build --config Release --target preview_depth_c -j 4; then
+    cmake --build $workpath/build --config Release --target preview_depth_c -j 4 &&
+    cmake --build $workpath/build --config Release --target face_identifier -j 4; then
     echo "== Build success"
     echo "== Run $workpath/build/example/cpp/example"
 else
@@ -20,7 +21,8 @@ else
     if cmake --build $workpath/build --config Release --target example &&
         cmake --build $workpath/build --config Release --target capture_raw &&
         cmake --build $workpath/build --config Release --target preview_depth &&
-        cmake --build $workpath/build --config Release --target preview_depth_c; then
+        cmake --build $workpath/build --config Release --target preview_depth_c &&
+        cmake --build $workpath/build --config Release --target face_identifier; then
         echo "== Build success"
         echo "== Run $workpath/build/example/cpp/example"
     else

--- a/example/cpp/CMakeLists.txt
+++ b/example/cpp/CMakeLists.txt
@@ -16,3 +16,7 @@ target_link_libraries(preview_usb ${CXXLIBS} ${OpenCV_LIBS})
 aux_source_directory(example DIR_SRCS)
 add_executable(example ${DIR_SRCS})
 target_link_libraries(example ${CXXLIBS} ${OpenCV_LIBS})
+
+add_executable(face_identifier face_identifier.cpp)
+target_include_directories(face_identifier PRIVATE ${CMAKE_SOURCE_DIR}/third_party/insightface ${OpenCV_INCLUDE_DIRS})
+target_link_libraries(face_identifier ${CXXLIBS} ${OpenCV_LIBS})

--- a/example/cpp/face_identifier.cpp
+++ b/example/cpp/face_identifier.cpp
@@ -1,0 +1,123 @@
+#include "ArducamTOFCamera.hpp"
+#include <opencv2/opencv.hpp>
+#include <iostream>
+#include <fstream>
+#include <map>
+#include <vector>
+#include <cmath>
+#include "../../third_party/insightface/face_recognizer_stub.hpp"
+
+using namespace Arducam;
+
+#define MAX_DISTANCE 4000
+using Embedding = std::vector<float>;
+static std::map<std::string, Embedding> database;
+
+static void save_embeddings(const std::string& path){
+    std::ofstream ofs(path, std::ios::binary);
+    size_t count = database.size();
+    ofs.write((char*)&count, sizeof(size_t));
+    for(auto& [name, emb]: database){
+        size_t len=name.size();
+        ofs.write((char*)&len, sizeof(size_t));
+        ofs.write(name.data(), len);
+        size_t dim=emb.size();
+        ofs.write((char*)&dim, sizeof(size_t));
+        ofs.write((char*)emb.data(), dim*sizeof(float));
+    }
+}
+
+static void load_embeddings(const std::string& path){
+    std::ifstream ifs(path, std::ios::binary);
+    if(!ifs) return;
+    size_t count; ifs.read((char*)&count, sizeof(size_t));
+    for(size_t i=0;i<count;++i){
+        size_t len; ifs.read((char*)&len, sizeof(size_t));
+        std::string name(len,' '); ifs.read(name.data(), len);
+        size_t dim; ifs.read((char*)&dim, sizeof(size_t));
+        Embedding emb(dim); ifs.read((char*)emb.data(), dim*sizeof(float));
+        database[name]=emb;
+    }
+}
+
+static float cosine_similarity(const Embedding& a, const Embedding& b){
+    float dot=0,na=0,nb=0;
+    for(size_t i=0;i<a.size();++i){
+        dot+=a[i]*b[i];
+        na+=a[i]*a[i];
+        nb+=b[i]*b[i];
+    }
+    return dot/(std::sqrt(na)*std::sqrt(nb)+1e-5f);
+}
+
+static void register_mode(ArducamTOFCamera& cam, insightface::FaceRecognizer& fr){
+    std::cout<<"Press r to register face, q to quit"<<std::endl;
+    while(true){
+        ArducamFrameBuffer* frame = cam.requestFrame(200);
+        if(!frame) continue;
+        FrameFormat fmt; frame->getFormat(FrameType::DEPTH_FRAME, fmt);
+        float* depth_ptr=(float*)frame->getData(FrameType::DEPTH_FRAME);
+        cv::Mat depth(fmt.height, fmt.width, CV_32F, depth_ptr);
+        cv::Mat img; depth.convertTo(img, CV_8U, 255.0/MAX_DISTANCE);
+        cv::cvtColor(img, img, cv::COLOR_GRAY2BGR);
+        auto faces = fr.detect(img);
+        for(auto& f: faces){ cv::rectangle(img, f.bbox, {0,255,0}, 2); }
+        cv::imshow("preview", img);
+        int key=cv::waitKey(1);
+        if(key=='q'){ cam.releaseFrame(frame); break; }
+        else if(key=='r' && !faces.empty()){
+            std::string name; std::cout<<"Name: "; std::cin>>name;
+            database[name]=fr.getEmbedding(img, faces[0]);
+            std::cout<<"Registered "<<name<<std::endl;
+        }
+        cam.releaseFrame(frame);
+    }
+    save_embeddings("embeddings.dat");
+}
+
+static void identify_mode(ArducamTOFCamera& cam, insightface::FaceRecognizer& fr){
+    load_embeddings("embeddings.dat");
+    std::cout<<"Press q to quit"<<std::endl;
+    while(true){
+        ArducamFrameBuffer* frame=cam.requestFrame(200);
+        if(!frame) continue;
+        FrameFormat fmt; frame->getFormat(FrameType::DEPTH_FRAME, fmt);
+        float* depth_ptr=(float*)frame->getData(FrameType::DEPTH_FRAME);
+        cv::Mat depth(fmt.height, fmt.width, CV_32F, depth_ptr);
+        cv::Mat img; depth.convertTo(img, CV_8U, 255.0/MAX_DISTANCE);
+        cv::cvtColor(img, img, cv::COLOR_GRAY2BGR);
+        auto faces=fr.detect(img);
+        for(auto& f: faces){
+            Embedding emb=fr.getEmbedding(img, f);
+            std::string best="unknown"; float best_score=0;
+            for(auto& [name, db_emb]: database){
+                float sc=cosine_similarity(emb, db_emb);
+                if(sc>best_score){ best_score=sc; best=name; }
+            }
+            cv::rectangle(img, f.bbox, {0,255,0}, 2);
+            cv::putText(img, best, {f.bbox.x, f.bbox.y-5}, cv::FONT_HERSHEY_SIMPLEX, 0.5, {0,255,0});
+        }
+        cv::imshow("preview", img);
+        int key=cv::waitKey(1);
+        if(key=='q'){ cam.releaseFrame(frame); break; }
+        cam.releaseFrame(frame);
+    }
+}
+
+int main(){
+    ArducamTOFCamera cam; ArducamFrameBuffer* frame;
+    if(cam.open(Connection::CSI,0)){
+        std::cerr<<"Failed to open camera"<<std::endl; return -1; }
+    if(cam.start(FrameType::DEPTH_FRAME)){
+        std::cerr<<"Failed to start camera"<<std::endl; return -1; }
+    cam.setControl(Control::RANGE, MAX_DISTANCE);
+
+    insightface::FaceRecognizer fr; fr.loadModel("models/antelopev2.onnx");
+    std::cout<<"Select mode (r=register, i=identify): ";
+    char m; std::cin>>m;
+    if(m=='r') register_mode(cam, fr);
+    else if(m=='i') identify_mode(cam, fr);
+
+    cam.stop(); cam.close();
+    return 0;
+}

--- a/example/python/insightface_register.py
+++ b/example/python/insightface_register.py
@@ -1,0 +1,66 @@
+import cv2
+import numpy as np
+import os
+import pickle
+import ArducamDepthCamera as ac
+from insightface.app import FaceAnalysis
+
+MAX_DISTANCE = 4000
+
+
+def main():
+    print("Arducam Depth Camera InsightFace Demo")
+    cam = ac.ArducamCamera()
+    ret = cam.open(ac.Connection.CSI, 0)
+    if ret != 0:
+        print("Failed to open camera. Error code:", ret)
+        return
+
+    ret = cam.start(ac.FrameType.DEPTH)
+    if ret != 0:
+        print("Failed to start camera. Error code:", ret)
+        cam.close()
+        return
+
+    cam.setControl(ac.Control.RANGE, MAX_DISTANCE)
+
+    face_app = FaceAnalysis(providers=['CPUExecutionProvider'])
+    face_app.prepare(ctx_id=0, det_size=(640, 640))
+
+    embeddings = {}
+    print("Press 'r' to register face, 'q' to quit")
+    while True:
+        frame = cam.requestFrame(2000)
+        if frame is not None and isinstance(frame, ac.DepthData):
+            depth_buf = frame.depth_data
+            preview = (depth_buf * (255.0 / MAX_DISTANCE)).astype(np.uint8)
+            preview = cv2.cvtColor(preview, cv2.COLOR_GRAY2BGR)
+            faces = face_app.get(preview)
+            for face in faces:
+                box = face.bbox.astype(int)
+                cv2.rectangle(preview, (box[0], box[1]), (box[2], box[3]), (0, 255, 0), 2)
+
+            cv2.imshow("preview", preview)
+            cam.releaseFrame(frame)
+        else:
+            continue
+
+        key = cv2.waitKey(1) & 0xFF
+        if key == ord('q'):
+            break
+        elif key == ord('r') and faces:
+            name = input("Enter name: ").strip()
+            embeddings[name] = faces[0].embedding
+            print(f"Registered {name}")
+
+    cam.stop()
+    cam.close()
+
+    if embeddings:
+        with open('registered_faces.pkl', 'wb') as f:
+            pickle.dump(embeddings, f)
+        print("Saved embeddings to registered_faces.pkl")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/python/requirements.txt
+++ b/example/python/requirements.txt
@@ -1,3 +1,4 @@
 ArducamDepthCamera
 opencv-python
 numpy<2.0.0
+insightface

--- a/third_party/insightface/README.md
+++ b/third_party/insightface/README.md
@@ -1,0 +1,13 @@
+# InsightFace C++ Integration
+
+This folder is a placeholder for the official [InsightFace](https://github.com/deepinsight/insightface) repository.
+
+To use the C++ example in this project, clone the InsightFace source here and build the C++ API:
+
+```bash
+git clone https://github.com/deepinsight/insightface.git third_party/insightface
+# build instructions can be found in the repository
+```
+
+After building, replace `face_recognizer_stub.hpp` with the real headers and make sure the ONNX model
+(e.g. `antelopev2.onnx`) is placed in the `models` directory.

--- a/third_party/insightface/face_recognizer_stub.hpp
+++ b/third_party/insightface/face_recognizer_stub.hpp
@@ -1,0 +1,21 @@
+#ifndef INSIGHTFACE_STUB_HPP
+#define INSIGHTFACE_STUB_HPP
+#include <opencv2/core.hpp>
+#include <vector>
+#include <string>
+
+namespace insightface {
+struct FaceInfo {
+    cv::Rect bbox;
+    std::vector<float> embedding;
+};
+
+class FaceRecognizer {
+public:
+    bool loadModel(const std::string&){return true;}
+    std::vector<FaceInfo> detect(const cv::Mat&){return {};}
+    std::vector<float> getEmbedding(const cv::Mat&, const FaceInfo&){return {};}
+};
+}
+
+#endif // INSIGHTFACE_STUB_HPP


### PR DESCRIPTION
## Summary
- create a stub header and placeholder folder for InsightFace
- add a new C++ face identification example that can register or identify faces
- build the new example via CMake and compile script
- document cloning InsightFace and running `face_identifier`

## Testing
- `bash compile.sh` *(fails: Could not find ArducamDepthCameraConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_684d2b70970c832c8ae5a6b52e9427d1